### PR TITLE
docs(claude): add agent onboarding and skills

### DIFF
--- a/.claude/skills/adding-flux-app/SKILL.md
+++ b/.claude/skills/adding-flux-app/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: adding-flux-app
+description: Add a new self-hosted application to the cluster by creating base + prod overlays under k3s/apps/. Use when the user asks to "deploy a new app", "add <app> to the cluster", "self-host <something>", or otherwise wants a new workload running. This skill covers raw-manifest apps (Deployment/Service/PVCs) — for Helm-chart-based infrastructure services, use the `adding-helmrelease` skill instead.
+---
+
+# Adding a Flux app
+
+Apps live under `k3s/apps/` with a two-layer Kustomize pattern: a `base/` with the portable manifests, and a `prod/` overlay with environment-specific pieces (PVCs, ConfigMap values, encrypted secrets). Flux's `apps` Kustomization points at `k3s/apps/prod`, which references `../base/<app>`.
+
+## When to use raw manifests vs a HelmRelease
+
+- **Raw manifests (this skill)** — single-container apps, arr-stack tools, most self-hosted web apps. Think `jellyfin`, `sonarr`, `vaultwarden`, `gatus`.
+- **HelmRelease** — multi-component systems with upstream charts (observability stacks, operators, ingress controllers). Use `adding-helmrelease`.
+
+If in doubt, check if an official/linuxserver container image exists and the app is a single Deployment — if yes, use raw manifests.
+
+## Directory shape to create
+
+Mirror `k3s/apps/base/jellyfin/` and `k3s/apps/prod/jellyfin/`:
+
+```
+k3s/apps/base/<app>/
+├── namespace.yaml
+├── deployment.yaml
+├── service.yaml
+└── kustomization.yaml   # resources: [./namespace.yaml, ./deployment.yaml, ./service.yaml]
+
+k3s/apps/prod/<app>/
+├── config.yaml          # ConfigMap with env (TZ, PUID, PGID, app-specific vars)
+├── storage-<name>.yaml  # one PVC per mount path
+├── *.k8s.enc.yaml       # encrypted Secrets (optional)
+└── kustomization.yaml   # resources: all of the above; typically also `../../base/<app>` if base is referenced via overlay
+```
+
+Two reference patterns exist in the repo — check both before copying:
+
+- **Overlay style** (jellyfin): `prod/jellyfin/kustomization.yaml` only lists prod-specific resources; base is merged via the parent `prod/kustomization.yaml` alongside `../base/<app>`. Read `k3s/apps/base/kustomization.yaml` — it lists every `./<app>` folder.
+- **Direct base reference**: some apps reference `../../base/<app>` from their prod `kustomization.yaml`.
+
+Match whichever the neighbor app uses so patches and references stay consistent.
+
+## Steps
+
+1. **Pick a neighbor to clone from.** For an arr-stack app: copy `sonarr`. For a simple web UI: copy `it-tools` or `miniflux`. For media with GPU needs: `jellyfin`. Copy the directory shape; don't start from scratch.
+
+2. **Create `k3s/apps/base/<app>/`** with:
+   - `namespace.yaml` — `apiVersion: v1, kind: Namespace, metadata.name: <app>`.
+   - `deployment.yaml` — image pinned by tag (Renovate will pin the digest). PUID/PGID/TZ from the ConfigMap in prod. Resource requests if known.
+   - `service.yaml` — `ClusterIP` on the app's port. Traefik picks it up via IngressRoute in `infrastructure/configs/prod/traefik/`.
+   - `kustomization.yaml` listing the three resources.
+
+3. **Create `k3s/apps/prod/<app>/`** with:
+   - `config.yaml` — `ConfigMap` with prod env values.
+   - `storage-*.yaml` — one PVC per mount (config, cache, media via NFS, etc.). Copy storageClassName from a neighbor: `local-path` for app state, `nfs-client` for shared media.
+   - `<app>-secrets.k8s.enc.yaml` if secrets are needed — create plaintext first, then `sops --encrypt --in-place`. See the `managing-sops-secrets` skill.
+   - `kustomization.yaml` listing everything in this folder.
+
+4. **Register the app in both parent kustomizations:**
+   - Append `- ./<app>` to `k3s/apps/base/kustomization.yaml`.
+   - Append `- ./<app>` to `k3s/apps/prod/kustomization.yaml` (read the file first — it may follow a slightly different pattern).
+
+5. **Add the ingress route** (if the app should be reachable externally) in `k3s/infrastructure/configs/prod/traefik/ingress-routes.yaml`. Copy the shape of an existing route. Hostnames route through Cloudflare Tunnels + Traefik — no port-forwarding needed.
+
+6. **Validate locally** (same checks CI runs):
+
+    ```bash
+    kustomize build k3s/apps/prod > /dev/null
+    kustomize build k3s/infrastructure/configs/prod > /dev/null
+    ```
+
+    Any error here ("accumulating resources", "no matches for kind", "field not declared") = fix before pushing.
+
+7. **Commit with a conventional message** (`feat(apps): add <app>`) and open a PR. CI runs Kustomize Build + Datree policy check + SOPS encryption check. Once merged, Flux picks it up within ~10 minutes. Speed it up with `flux reconcile kustomization apps --with-source` if needed.
+
+## Common mistakes
+
+- Forgetting to add the new folder to `k3s/apps/base/kustomization.yaml` or `k3s/apps/prod/kustomization.yaml`. The app just silently doesn't deploy — no CI error, no Flux error. Always update both.
+- Wrong `storageClassName`. `local-path` is node-local (lost if the node dies); use it for caches. `nfs-client` for anything that needs to survive node loss or be shared. Check with `kubectl get sc`.
+- Hardcoding versions in `image: foo:1.2.3` — fine, Renovate pins and updates them. Don't use `:latest`; Renovate can't diff it.
+- Creating a `Secret` without the `.k8s.enc.yaml` extension. `.sops.yaml`'s creation rule won't fire, encryption won't happen the way Flux expects. See `managing-sops-secrets`.
+- Putting the PVC in `base/`. PVC sizes are environment-specific — keep them in `prod/` so a future staging overlay can differ.
+
+## What Renovate needs
+
+For Renovate to track your app's image, just pin a real tag (`image: lscr.io/linuxserver/sonarr:4.0.11`). If the image belongs to a coupled group (arr-stack, jellyfin-stack, loki-promtail, cloudnative-pg), check `renovate.json` — you may need to add the package to an existing group so it updates together with its siblings.

--- a/.claude/skills/adding-helmrelease/SKILL.md
+++ b/.claude/skills/adding-helmrelease/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: adding-helmrelease
+description: Add a new Flux HelmRelease (and HelmRepository if needed) under k3s/infrastructure/controllers/ to deploy a Helm-packaged cluster service. Use when the user wants to install an operator, ingress controller, observability stack, or any upstream Helm chart — e.g. "add cert-manager", "install kube-prometheus-stack", "deploy <operator>". For single-Deployment self-hosted apps, use the `adding-flux-app` skill instead.
+---
+
+# Adding a HelmRelease
+
+Cluster services backed by Helm charts live under `k3s/infrastructure/controllers/`. Flux's `infra-controllers` Kustomization reconciles `k3s/infrastructure/controllers/prod`, which layers over `base/`. Everything here depends on `apps` having reconciled first (see `k3s/clusters/prod/infrastructure.yaml`).
+
+## Directory shape
+
+Mirror `k3s/infrastructure/controllers/base/loki/`:
+
+```
+k3s/infrastructure/controllers/base/<name>/
+├── namespace.yaml
+├── helm-release.yaml        # HelmRelease CR
+├── helm-repository.yaml     # HelmRepository CR (if the chart source is new)
+└── kustomization.yaml       # resources: [./namespace.yaml, ./helm-repository.yaml, ./helm-release.yaml]
+```
+
+If the chart lives in an existing `HelmRepository` (grafana, fluxcd, cert-manager, bitnami, etc. — grep `kind: HelmRepository` to find them), skip `helm-repository.yaml` and reference the existing one by name + namespace.
+
+A `prod/` overlay at `k3s/infrastructure/controllers/prod/<name>/` is only needed when prod values differ from base (extra resources, patched values, prod-specific secrets). Many services have no prod overlay at all.
+
+## Steps
+
+1. **Find the chart.** Official Helm repo URL + chart name + latest stable version. Prefer OCI registries (`oci://...`) when available — Renovate handles OCI refs cleanly and `flux` disables digest pinning for them (see `renovate.json`).
+
+2. **Pick a neighbor** with the same shape:
+   - OCI chart: `cloudflared` or similar.
+   - Classic HelmRepository chart: `loki` (grafana repo), `cert-manager`.
+   - Operator with CRDs: `cloudnativepg`, `intel-device-plugin-operator`.
+
+3. **Create `k3s/infrastructure/controllers/base/<name>/`:**
+
+    `namespace.yaml`:
+    ```yaml
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: <name>
+    ```
+
+    `helm-repository.yaml` (only if chart source is new to the repo):
+    ```yaml
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: HelmRepository
+    metadata:
+      name: <repo-short-name>
+      namespace: <name>   # or a shared one like `monitoring`, matching neighbors
+    spec:
+      interval: 1h
+      url: https://<chart-host>
+    ```
+
+    `helm-release.yaml`:
+    ```yaml
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    metadata:
+      name: <name>
+      namespace: <name>
+    spec:
+      interval: 10m
+      timeout: 5m
+      chart:
+        spec:
+          chart: <chart-name>
+          version: <x.y.z>
+          sourceRef:
+            kind: HelmRepository
+            name: <repo-short-name>
+            namespace: <repo-namespace>   # must match the HelmRepository, not the release
+      values:
+        # minimal values — override only what's needed
+    ```
+
+    `kustomization.yaml`:
+    ```yaml
+    resources:
+      - ./namespace.yaml
+      - ./helm-repository.yaml   # omit if reusing an existing repo
+      - ./helm-release.yaml
+    ```
+
+4. **Register in the parent kustomization:** append `- ./<name>` to `k3s/infrastructure/controllers/base/kustomization.yaml`.
+
+5. **Prod overlay (only if needed):** create `k3s/infrastructure/controllers/prod/<name>/kustomization.yaml` that references `../../base/<name>` plus any prod-specific patches, and append `- ./<name>` to `k3s/infrastructure/controllers/prod/kustomization.yaml`. Skip this if base is sufficient — many services here do.
+
+6. **Validate locally:**
+
+    ```bash
+    kustomize build k3s/infrastructure/controllers/prod > /dev/null
+    ```
+
+    If it fails with "no matches for kind HelmRelease" that means Flux CRDs aren't in your local toolchain — ignore; CI uses a different validator. Structural errors ("accumulating resources", missing files) are real and must be fixed.
+
+7. **Commit + PR.** On merge, Flux reconciles `infra-controllers` on a 1h interval. To push it immediately:
+
+    ```bash
+    flux reconcile source git flux-system
+    flux reconcile kustomization infra-controllers --with-source
+    flux get helmrelease -A <name>
+    ```
+
+## Values: where to put them
+
+- **Small, stable values** (a few dozen lines): inline under `spec.values` in `helm-release.yaml`. This is what most releases in this repo do (see `loki`, `traefik`).
+- **Large/sensitive values**: use `spec.valuesFrom` to pull from a ConfigMap or Secret. Reference by name; put the CM/Secret in the same namespace and list it in the `kustomization.yaml`. Encrypt secrets as `*.k8s.enc.yaml` (see the `managing-sops-secrets` skill).
+
+## Common mistakes
+
+- **Wrong `sourceRef.namespace`.** The `HelmRepository` often lives in a shared namespace (`monitoring`, `flux-system`) while the HelmRelease lives in its own. Copy both from a working neighbor — getting this wrong is the #1 reason a HelmRelease shows `chart reconciliation failed`.
+- **Forgetting to add the folder to the parent `kustomization.yaml`.** Kustomize silently skips it; Flux never deploys anything; no CI error. Always update the parent.
+- **CRDs not installed yet.** If the chart ships CRDs, set `spec.install.crds: Create` and `spec.upgrade.crds: CreateReplace` in the HelmRelease. Otherwise operators depending on those CRDs will fail to start.
+- **Pinning `version:` to `*` or a range.** Renovate wants a concrete version to diff against. Always pin `x.y.z`. Renovate will open a PR when a newer version is available.
+- **Namespace not created.** The `HelmRelease` must have a target namespace that exists — include `namespace.yaml` in the kustomization unless you're targeting `kube-system` or another shared namespace.
+
+## When a HelmRelease fails to reconcile
+
+```bash
+flux get helmrelease -A           # find the failing release
+flux logs --kind=HelmRelease --name=<name> --namespace=<ns> --since=15m
+kubectl describe helmrelease <name> -n <ns>
+kubectl get events -n <ns> --sort-by=.lastTimestamp | tail -30
+```
+
+See the `troubleshooting-flux` skill for the full triage flow.

--- a/.claude/skills/conventional-git/SKILL.md
+++ b/.claude/skills/conventional-git/SKILL.md
@@ -38,7 +38,7 @@ No ticket prefix — this homelab has no external ticket system.
 | Type          | Purpose                                                              | Example                                |
 | ------------- | -------------------------------------------------------------------- | -------------------------------------- |
 | `main`        | Primary integration branch; Flux reconciles from here                | —                                      |
-| `feature/`    | Adding something new that did not exist before (**not** `feat/`)     | `feature/add-audiobookshelf`           |
+| `feat/`       | Adding something new that did not exist before (**not** `feature/`)  | `feat/add-audiobookshelf`              |
 | `fix/`        | Fixing something broken; normal flow                                 | `fix/traefik-middleware-order`         |
 | `hotfix/`     | Urgent production fix; cut from `main`, merged back immediately      | `hotfix/sops-age-key-rotation`         |
 | `chore/`      | No runtime behavior change: deps, CI, docs, formatting, renovate     | `chore/bump-cert-manager-1.16`         |
@@ -49,19 +49,19 @@ There is no `release/` branch — this is a GitOps homelab with a single `prod` 
 
 | Rule                                | Correct                          | Incorrect                        |
 | ----------------------------------- | -------------------------------- | -------------------------------- |
-| Lowercase only                      | `feature/add-audiobookshelf`     | `feature/Add-Audiobookshelf`     |
+| Lowercase only                      | `feat/add-audiobookshelf`        | `feat/Add-Audiobookshelf`        |
 | Hyphens as word separators          | `fix/fix-traefik-route`          | `fix/fix_traefik_route`          |
-| No spaces                           | `feature/add-lazylibrarian`      | `feature/add lazylibrarian`      |
-| No consecutive hyphens              | `feature/add-gatus`              | `feature/add--gatus`             |
-| No leading or trailing hyphens      | `feature/add-gatus`              | `feature/-add-gatus`             |
+| No spaces                           | `feat/add-lazylibrarian`         | `feat/add lazylibrarian`         |
+| No consecutive hyphens              | `feat/add-gatus`                 | `feat/add--gatus`                |
+| No leading or trailing hyphens      | `feat/add-gatus`                 | `feat/-add-gatus`                |
 | No trailing dots                    | `chore/bump-loki-6.55`           | `chore/bump-loki-6.55.`          |
 | Alphanumerics, hyphens, dots only   | `chore/update-k3s-v1.32`         | `chore/update-k3s@v1.32`         |
 
 ### Examples
 
 ```
-feature/add-audiobookshelf
-feature/add-postgres-scheduled-backups
+feat/add-audiobookshelf
+feat/add-postgres-scheduled-backups
 fix/traefik-ingress-route-for-grafana
 fix/cloudflared-tunnel-restart-loop
 hotfix/sops-age-key-rotation
@@ -97,7 +97,7 @@ Format:
 
 | Type       | Use When                                              |
 | ---------- | ----------------------------------------------------- |
-| `feature`  | Introducing new functionality — new app, new controller, new CI job (**not** `feat`) |
+| `feat`     | Introducing new functionality — new app, new controller, new CI job (**not** `feature`) |
 | `fix`      | Patching a bug or broken manifest                     |
 | `refactor` | Restructuring manifests — no behavior change (e.g. moving a resource between overlays) |
 | `docs`     | Documentation changes only (README, CLAUDE.md, skills, inline comments) |
@@ -124,7 +124,7 @@ Scope narrows the context to a subsystem. Defined per this repo:
 **CI / meta:**
 `ci`, `workflows`, `docs`, `readme`
 
-Pick the narrowest scope that still captures the change. `feature(jellyfin)` beats `feature(apps)` when only jellyfin changes.
+Pick the narrowest scope that still captures the change. `feat(jellyfin)` beats `feat(apps)` when only jellyfin changes.
 
 ### Breaking Changes
 
@@ -147,14 +147,14 @@ BREAKING CHANGE: requires manual PVC re-creation; see runbook in docs/.
 
 | Rule                        | Correct                         | Incorrect                       |
 | --------------------------- | ------------------------------- | ------------------------------- |
-| Type lowercase              | `feature:`                      | `Feature:`                      |
+| Type lowercase              | `feat:`                         | `Feat:`                         |
 | Space after colon           | `fix: resolve bug`              | `fix:resolve bug`               |
-| Description lowercase       | `feature: add gatus dashboard`  | `feature: Add Gatus dashboard`  |
+| Description lowercase       | `feat: add gatus dashboard`     | `feat: Add Gatus dashboard`     |
 | Imperative mood             | `fix: remove broken redirect`   | `fix: removed broken redirect`  |
 | No trailing period          | `docs: update architecture diagram` | `docs: update architecture diagram.` |
 | One blank line before body  | description → blank line → body | body directly after description |
 | `BREAKING CHANGE` uppercase | `BREAKING CHANGE:`              | `breaking change:`              |
-| Single responsibility       | one concern per commit          | mixing feature + refactor + fix |
+| Single responsibility       | one concern per commit          | mixing feat + refactor + fix    |
 
 Each commit must leave the repo in a state where `kustomize build` succeeds on all three overlays.
 
@@ -197,7 +197,7 @@ Good verbs by type:
 
 | Type       | Verbs                                                   |
 | ---------- | ------------------------------------------------------- |
-| `feature`  | add, introduce, expose, enable, support                 |
+| `feat`     | add, introduce, expose, enable, support                 |
 | `fix`      | fix, resolve, prevent, correct, handle                  |
 | `refactor` | extract, move, rename, simplify, restructure, split     |
 | `docs`     | document, update, correct, clarify                      |
@@ -234,15 +234,15 @@ Never add AI attribution or tool metadata.
 
 ### Anti-patterns
 
-| Anti-pattern                                 | Problem                                       |
-| -------------------------------------------- | --------------------------------------------- |
-| `fix stuff`, `update`, `changes`, `WIP`      | No information — useless history              |
-| `fix: fixed the bug` — past tense            | Fails the imperative mood test                |
-| `feat: Add login` — wrong type, capitalized  | Use `feature`; description must be lowercase  |
-| Subject contains "and"                       | Multi-concern commit — split it               |
-| Body restates the diff                       | Noise — the reader has `git show`             |
-| `Co-Authored-By: Claude …`                   | **Forbidden** — see Hard Constraints          |
-| Body longer than one sentence                | Keep it tight; one sentence only              |
+| Anti-pattern                                    | Problem                                    |
+| ----------------------------------------------- | ------------------------------------------ |
+| `fix stuff`, `update`, `changes`, `WIP`         | No information — useless history           |
+| `fix: fixed the bug` — past tense               | Fails the imperative mood test             |
+| `feature: Add login` — wrong type, capitalized  | Use `feat`; description must be lowercase  |
+| Subject contains "and"                          | Multi-concern commit — split it            |
+| Body restates the diff                          | Noise — the reader has `git show`          |
+| `Co-Authored-By: Claude …`                      | **Forbidden** — see Hard Constraints       |
+| Body longer than one sentence                   | Keep it tight; one sentence only           |
 
 ---
 
@@ -257,7 +257,7 @@ docs: correct spelling in README
 With scope:
 
 ```
-feature(apps): add audiobookshelf
+feat(apps): add audiobookshelf
 ```
 
 With body (one sentence, explains why):

--- a/.claude/skills/conventional-git/SKILL.md
+++ b/.claude/skills/conventional-git/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: conventional-git
+description: Branch and commit naming conventions for this homelab. Follow these rules whenever creating branches or writing commit messages. Enforces the Conventional Branch and Conventional Commit specifications for this repository.
+when_to_use: "creating a branch, naming a branch, making a commit, writing a commit message, git commit, git checkout, commit format, branch format, branch name, how to commit, how to name a branch"
+user-invocable: true
+---
+
+# Conventional Git — Branch & Commit Conventions
+
+Apply these rules whenever creating branches or composing commit messages.
+If you cannot categorize a commit, it is doing too much — split it.
+
+---
+
+## Hard Constraints
+
+- **Never** add `Co-Authored-By:`, `Generated-by:`, or any trailer that attributes
+  authorship or assistance to an AI, tool, or model (Claude, Copilot, etc.).
+- **Never** mention AI involvement anywhere in a commit message — not in the subject, body,
+  or footer. The commit represents the human author's work.
+- Footers are only for `BREAKING CHANGE` or peer metadata (`Reviewed-by:`) when explicitly
+  requested. This repo has no issue tracker, so issue-ref footers (`Refs:`, `Fixes:`) do not apply.
+
+---
+
+## Branches
+
+Format:
+
+```
+type/description
+```
+
+No ticket prefix — this homelab has no external ticket system.
+
+### Branch Types
+
+| Type          | Purpose                                                              | Example                                |
+| ------------- | -------------------------------------------------------------------- | -------------------------------------- |
+| `main`        | Primary integration branch; Flux reconciles from here                | —                                      |
+| `feature/`    | Adding something new that did not exist before (**not** `feat/`)     | `feature/add-audiobookshelf`           |
+| `fix/`        | Fixing something broken; normal flow                                 | `fix/traefik-middleware-order`         |
+| `hotfix/`     | Urgent production fix; cut from `main`, merged back immediately      | `hotfix/sops-age-key-rotation`         |
+| `chore/`      | No runtime behavior change: deps, CI, docs, formatting, renovate     | `chore/bump-cert-manager-1.16`         |
+
+There is no `release/` branch — this is a GitOps homelab with a single `prod` environment reconciled continuously from `main`. Versioning happens per-component via Renovate, not per-repo.
+
+### Naming Rules
+
+| Rule                                | Correct                          | Incorrect                        |
+| ----------------------------------- | -------------------------------- | -------------------------------- |
+| Lowercase only                      | `feature/add-audiobookshelf`     | `feature/Add-Audiobookshelf`     |
+| Hyphens as word separators          | `fix/fix-traefik-route`          | `fix/fix_traefik_route`          |
+| No spaces                           | `feature/add-lazylibrarian`      | `feature/add lazylibrarian`      |
+| No consecutive hyphens              | `feature/add-gatus`              | `feature/add--gatus`             |
+| No leading or trailing hyphens      | `feature/add-gatus`              | `feature/-add-gatus`             |
+| No trailing dots                    | `chore/bump-loki-6.55`           | `chore/bump-loki-6.55.`          |
+| Alphanumerics, hyphens, dots only   | `chore/update-k3s-v1.32`         | `chore/update-k3s@v1.32`         |
+
+### Examples
+
+```
+feature/add-audiobookshelf
+feature/add-postgres-scheduled-backups
+fix/traefik-ingress-route-for-grafana
+fix/cloudflared-tunnel-restart-loop
+hotfix/sops-age-key-rotation
+chore/bump-cert-manager-1.16
+chore/renovate-group-media-stack
+```
+
+---
+
+## Commits
+
+Format:
+
+```
+<type>(<scope>): <description>
+
+[optional body — one sentence]
+
+[optional footer(s)]
+```
+
+### Parts
+
+| Part          | Required | Rules                                                                                   |
+| ------------- | -------- | --------------------------------------------------------------------------------------- |
+| `type`        | Yes      | One of the defined types below                                                          |
+| `scope`       | No       | Noun in parentheses describing the affected area, e.g. `(flux)`, `(apps)`, `(sops)`     |
+| `description` | Yes      | Lowercase, imperative mood, no trailing period, ≤72 chars total with prefix            |
+| `body`        | No       | **One sentence.** One blank line after description. Explains **why**, not what.         |
+| `footer`      | No       | One blank line after body. Used for `BREAKING CHANGE` only.                             |
+
+### Types
+
+| Type       | Use When                                              |
+| ---------- | ----------------------------------------------------- |
+| `feature`  | Introducing new functionality — new app, new controller, new CI job (**not** `feat`) |
+| `fix`      | Patching a bug or broken manifest                     |
+| `refactor` | Restructuring manifests — no behavior change (e.g. moving a resource between overlays) |
+| `docs`     | Documentation changes only (README, CLAUDE.md, skills, inline comments) |
+| `style`    | YAML formatting, whitespace, linting — no logic change |
+| `build`    | Changes to Terraform providers, Ansible roles, base image pinning |
+| `ci`       | GitHub Actions workflow changes                       |
+| `chore`    | Housekeeping — Renovate bumps, minor config, cleanup that fits none of the above |
+
+One commit, one type. If you cannot pick one, the commit is doing too much — split it.
+
+### Scope
+
+Scope narrows the context to a subsystem. Defined per this repo:
+
+**GitOps / Kubernetes:**
+`flux`, `apps`, `infra`, `controllers`, `configs`, `traefik`, `cert-manager`, `cloudflared`, `loki`, `grafana`, `cnpg`, `redis`, `tailscale`, `nfs`, …
+
+**Per-app scopes** (when a change is scoped to one workload):
+`jellyfin`, `sonarr`, `radarr`, `prowlarr`, `sabnzbd`, `gatus`, `vaultwarden`, `paperless-ngx`, `audiobookshelf`, `beszel`, …
+
+**Infrastructure / tooling:**
+`terraform`, `ansible`, `haproxy`, `keepalived`, `sops`, `renovate`, `claude`, …
+
+**CI / meta:**
+`ci`, `workflows`, `docs`, `readme`
+
+Pick the narrowest scope that still captures the change. `feature(jellyfin)` beats `feature(apps)` when only jellyfin changes.
+
+### Breaking Changes
+
+For a homelab, "breaking" means: requires manual intervention beyond a Flux reconcile
+(e.g. PVC migration, manual Talos config apply, age key rotation, namespace deletion).
+
+Use `!` in the type line (preferred):
+
+```
+refactor(cnpg)!: migrate postgres storage to local-path
+```
+
+Or use a footer:
+
+```
+BREAKING CHANGE: requires manual PVC re-creation; see runbook in docs/.
+```
+
+### Rules
+
+| Rule                        | Correct                         | Incorrect                       |
+| --------------------------- | ------------------------------- | ------------------------------- |
+| Type lowercase              | `feature:`                      | `Feature:`                      |
+| Space after colon           | `fix: resolve bug`              | `fix:resolve bug`               |
+| Description lowercase       | `feature: add gatus dashboard`  | `feature: Add Gatus dashboard`  |
+| Imperative mood             | `fix: remove broken redirect`   | `fix: removed broken redirect`  |
+| No trailing period          | `docs: update architecture diagram` | `docs: update architecture diagram.` |
+| One blank line before body  | description → blank line → body | body directly after description |
+| `BREAKING CHANGE` uppercase | `BREAKING CHANGE:`              | `breaking change:`              |
+| Single responsibility       | one concern per commit          | mixing feature + refactor + fix |
+
+Each commit must leave the repo in a state where `kustomize build` succeeds on all three overlays.
+
+---
+
+## Recipe: Writing a Commit Message
+
+### 1. Check atomicity
+
+Describe the change in one sentence without "and". If you cannot, split the commit.
+Use `git add -p` to stage individual hunks when concerns are mixed in the working tree.
+
+| Signal                                                      | Action                  |
+| ----------------------------------------------------------- | ----------------------- |
+| Subject needs "and"                                         | Two commits             |
+| Two types apply (e.g. `fix` + `refactor`)                   | Two commits             |
+| Multiple independent artifacts, even of the same type       | One commit per artifact |
+| WIP commits in the branch                                   | Squash before pushing   |
+
+**Same type ≠ same commit.** Adding three skills, three renovate rules, or three unrelated
+manifests in a single `chore` commit is still three concerns. Each independently reviewable
+or deployable unit gets its own commit.
+
+### 2. Write the subject
+
+`type[(scope)]: description`
+
+The subject is the heading. It must stand alone and be self-sufficient.
+
+**Imperative mood test** — the subject must complete this naturally:
+
+> "If applied, this commit will **[your subject]**."
+
+```
+✓ fix traefik middleware order for jellyfin
+✗ fixed traefik middleware order for jellyfin   ← past tense, fails the test
+```
+
+Good verbs by type:
+
+| Type       | Verbs                                                   |
+| ---------- | ------------------------------------------------------- |
+| `feature`  | add, introduce, expose, enable, support                 |
+| `fix`      | fix, resolve, prevent, correct, handle                  |
+| `refactor` | extract, move, rename, simplify, restructure, split     |
+| `docs`     | document, update, correct, clarify                      |
+| `style`    | format, reformat, align                                 |
+| `build`    | upgrade, bump, migrate, add, remove                     |
+| `ci`       | configure, update, add, fix                             |
+| `chore`    | update, remove, replace, clean up                       |
+
+### 3. Add a body only when needed
+
+The diff shows **what** changed. The body explains **why** — the motivation, the constraint,
+the non-obvious decision. Skip it when the subject is self-evident.
+
+**The body is one sentence.** No bullet lists, no multi-line explanations.
+
+```
+✓ Default chunks-cache of 8GiB exceeded node memory under light load.
+✗ Changed the chunks-cache memory because the default was too high
+  and caused OOM kills on the loki pod when running alongside other
+  workloads, especially during backup windows.   ← too long
+```
+
+One blank line separates the subject from the body.
+
+### 4. Add footers sparingly
+
+Footers come after a blank line following the body. Use them only for:
+
+```
+BREAKING CHANGE: …       ← required for changes that need manual intervention
+```
+
+Never add AI attribution or tool metadata.
+
+### Anti-patterns
+
+| Anti-pattern                                 | Problem                                       |
+| -------------------------------------------- | --------------------------------------------- |
+| `fix stuff`, `update`, `changes`, `WIP`      | No information — useless history              |
+| `fix: fixed the bug` — past tense            | Fails the imperative mood test                |
+| `feat: Add login` — wrong type, capitalized  | Use `feature`; description must be lowercase  |
+| Subject contains "and"                       | Multi-concern commit — split it               |
+| Body restates the diff                       | Noise — the reader has `git show`             |
+| `Co-Authored-By: Claude …`                   | **Forbidden** — see Hard Constraints          |
+| Body longer than one sentence                | Keep it tight; one sentence only              |
+
+---
+
+## Examples
+
+Minimal — subject only:
+
+```
+docs: correct spelling in README
+```
+
+With scope:
+
+```
+feature(apps): add audiobookshelf
+```
+
+With body (one sentence, explains why):
+
+```
+fix(loki): reduce chunks-cache allocated memory to 1 GiB
+
+Default 8 GiB exceeded node memory alongside the promtail daemonset.
+```
+
+Renovate-style bump:
+
+```
+chore(deps): update loki helm chart to 6.56.0
+```
+
+Breaking change:
+
+```
+refactor(cnpg)!: migrate postgres storage to local-path
+```
+
+With body and breaking change:
+
+```
+refactor(cnpg)!: migrate postgres storage to local-path
+
+StorageClass nfs-client could not satisfy CNPG's fsync guarantees.
+
+BREAKING CHANGE: requires manual PVC re-creation and WAL restore from R2.
+```

--- a/.claude/skills/managing-sops-secrets/SKILL.md
+++ b/.claude/skills/managing-sops-secrets/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: managing-sops-secrets
+description: Encrypt, decrypt, edit, and rotate SOPS+age-encrypted secrets in this homelab. Use when the user mentions SOPS, age, encrypting a secret, editing a `.enc.yaml` or `.k8s.enc.yaml` file, creating a Kubernetes Secret that Flux will decrypt, or when CI fails with "NOT encrypted" in the SOPS Encryption Check workflow.
+---
+
+# Managing SOPS secrets
+
+All sensitive values in this repo are encrypted with [SOPS](https://github.com/getsops/sops) using a single [age](https://github.com/FiloSottile/age) recipient before they touch Git. Flux decrypts them in-cluster using the `sops-age` Secret in the `flux-system` namespace.
+
+## Conventions that matter
+
+Two filename patterns, each with different encryption scope (see `.sops.yaml`):
+
+| Pattern | Scope | Used for |
+|---|---|---|
+| `*.k8s.enc.yaml` | Only `data` and `stringData` fields encrypted | Kubernetes `Secret` resources — metadata stays readable so Kustomize can reference the name |
+| `*.enc.yaml` | Entire file encrypted | Ansible/Terraform variable files |
+
+Recipient (public): `age1ys5az3gtql0nut2ldf88waz3jkmwzuvfl7gcrn9sja2luvnaud2s6u3834`
+
+Private key on Paul's machine: `~/homelab.agekey` (exported as `SOPS_AGE_KEY_FILE` via `.envrc`; `direnv allow` if not active).
+
+## Creating a new Kubernetes Secret
+
+1. Write the Secret as plaintext YAML at the target path with a `.k8s.enc.yaml` extension — e.g. `k3s/apps/prod/<app>/db-secrets.k8s.enc.yaml`:
+
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: <app>-db-credentials
+      namespace: <app>
+    type: Opaque
+    stringData:
+      username: <user>
+      password: <pass>
+    ```
+
+2. Encrypt in place:
+
+    ```bash
+    sops --encrypt --in-place k3s/apps/prod/<app>/db-secrets.k8s.enc.yaml
+    ```
+
+3. Add the file to the parent `kustomization.yaml` under `resources:`. Kustomize won't pick it up otherwise.
+
+4. Verify: open the file — `data`/`stringData` values must be unreadable, `metadata` must still be readable, and a `sops:` block must be present at the bottom.
+
+## Editing an existing encrypted file
+
+Never open a `.enc.yaml` in a normal editor and save — the file won't decrypt after that. Always use:
+
+```bash
+sops edit k3s/apps/prod/<app>/db-secrets.k8s.enc.yaml
+```
+
+SOPS decrypts to a temp file, opens `$EDITOR`, re-encrypts on save, and wipes the temp file.
+
+To just inspect without editing:
+
+```bash
+sops --decrypt k3s/apps/prod/<app>/db-secrets.k8s.enc.yaml
+```
+
+## Creating a Terraform/Ansible secret file
+
+Use the `*.enc.yaml` (not `.k8s.enc.yaml`) extension so the whole-file rule in `.sops.yaml` applies. Example paths: `terraform/cluster-provisioning/provider-secrets.enc.yaml`, `ansible/playbooks/cluster-provisioning/secrets/k3s-cluster-secrets.enc.yaml`.
+
+## Verifying everything is encrypted (matches CI)
+
+CI runs this in `.github/workflows/sops-encryption-check.yaml` — replicate locally before pushing:
+
+```bash
+find . -name "*.enc.yaml" -not -path "./.git/*" -print0 \
+  | xargs -0 -I {} sh -c 'grep -q "^sops:" "{}" || echo "NOT encrypted: {}"'
+```
+
+Any output = a file will fail CI. Encrypt it before pushing.
+
+## When Flux can't decrypt (fresh cluster or rotated key)
+
+Symptoms: `flux get kustomization` shows `decryption provider: sops: Failed to decrypt ...` on apps or infra.
+
+Fix: re-upload the age key to the cluster:
+
+```bash
+./apply-sops-age.sh
+```
+
+This is the one-liner at the repo root. It reads `~/homelab.agekey` and recreates the `sops-age` Secret in `flux-system`. Flux picks up the new key on the next reconcile (force it with `flux reconcile kustomization apps --with-source`).
+
+## Rotating the age key (rare, disruptive)
+
+Only do this if the private key is compromised. Outline — ask the user before executing each step:
+
+1. Generate new key: `age-keygen -o ~/homelab.agekey.new`.
+2. Update `.sops.yaml` with the new public key.
+3. Re-encrypt every `*.enc.yaml` file: `sops updatekeys <file>` for each (script it with `find`).
+4. Commit + push (CI must still pass — old and new keys can coexist in `.sops.yaml` during the transition).
+5. Replace `~/homelab.agekey` with the new key, re-run `./apply-sops-age.sh`.
+6. Once Flux reconciles successfully, remove the old recipient from `.sops.yaml` and re-run `sops updatekeys` everywhere.
+
+## Anti-patterns to catch
+
+- Committing a `.enc.yaml` without the `sops:` trailer — CI will block it, but don't push it in the first place.
+- Hand-editing `data:` values in a `.k8s.enc.yaml` — they're base64 ciphertext, not plaintext. Use `sops edit`.
+- Creating `secret.yaml` (unencrypted name) for a Kubernetes Secret. Always use the `.k8s.enc.yaml` extension so the creation rule fires.
+- Dropping a plaintext copy at `secret.dec.yaml` or similar "for now" — these get committed by accident.

--- a/.claude/skills/troubleshooting-flux/SKILL.md
+++ b/.claude/skills/troubleshooting-flux/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: troubleshooting-flux
+description: Diagnose why a Flux Kustomization or HelmRelease isn't reconciling, why a change in Git hasn't reached the cluster, or why resources are stuck/erroring. Use when the user says something like "Flux isn't picking up my change", "the HelmRelease is failing", "kustomization shows not ready", "my PR merged but nothing changed", "app isn't deployed", or when they share Flux error output.
+---
+
+# Troubleshooting Flux
+
+Flux has three moving parts: a **GitRepository source** that polls `main`, **Kustomizations** that render + apply manifests, and **HelmReleases** that install charts. A symptom can live in any of them — the trick is to walk the chain top-down and find the first red flag.
+
+## The 30-second triage
+
+Run these three first — one of them almost always reveals the problem:
+
+```bash
+flux get sources git -A
+flux get kustomization -A
+flux get helmrelease -A
+```
+
+Look at the `READY` column. `True` = healthy. `False` = error, read `STATUS` for the message. `Unknown` = in-progress or never reconciled.
+
+Common patterns:
+
+| `READY` / `STATUS` fragment | What it means | Next step |
+|---|---|---|
+| Source `False`, `failed to checkout`, `authentication required` | Flux can't reach GitHub | Check `flux-system` pods, network, any deploy key rotation |
+| Kustomization `False`, `decryption provider: sops: Failed to decrypt` | Age key missing/wrong in cluster | `./apply-sops-age.sh`, see `managing-sops-secrets` |
+| Kustomization `False`, `accumulating resources`, `no such file` | A `kustomization.yaml` references a missing file/folder | Run `kustomize build <path>` locally on the failing path |
+| Kustomization `False`, `dependency ... is not ready` | Parent Kustomization is the real problem | Work on the dependency first (apps → infra-controllers → infra-configs) |
+| HelmRelease `False`, `chart reconciliation failed` | HelmRepository/HelmChart source broken or chart version missing | `flux get source chart -A` + `flux get source helm -A` |
+| HelmRelease `False`, `install retries exhausted` | Chart values wrong, CRDs missing, or target namespace issue | `kubectl describe helmrelease` + `kubectl logs` of the chart's pods |
+| Kustomization `Unknown` forever | Never reconciled | `flux reconcile kustomization <name> --with-source` |
+
+## Deeper: "my commit merged but nothing changed"
+
+1. **Is Flux actually pulling?**
+
+    ```bash
+    flux get source git flux-system
+    ```
+
+    Compare the commit SHA in `REVISION` with `git rev-parse origin/main`. If stale, force:
+
+    ```bash
+    flux reconcile source git flux-system
+    ```
+
+2. **Is the Kustomization applying?**
+
+    ```bash
+    flux get kustomization -A
+    ```
+
+    `apps` runs every 10m; `infra-controllers` and `infra-configs` run every 1h. If your change is in infra and you're impatient:
+
+    ```bash
+    flux reconcile kustomization infra-controllers --with-source
+    ```
+
+3. **Is the resource actually in the rendered output?**
+
+    ```bash
+    kustomize build k3s/apps/prod | grep -A3 "name: <your-resource>"
+    ```
+
+    If not there → you probably forgot to add the new file/folder to a parent `kustomization.yaml`. Kustomize silently skips unreferenced files. Fix by appending to the right `kustomization.yaml` and re-committing.
+
+4. **Is it in the cluster?**
+
+    ```bash
+    kubectl get <kind> -A | grep <name>
+    kubectl describe <kind> <name> -n <ns>
+    ```
+
+    If `describe` shows `managed-by: kustomize-controller`, Flux did apply it — the problem is in the resource itself (image pull, readiness probe, etc.), not in Flux.
+
+## HelmRelease-specific debugging
+
+```bash
+flux logs --kind=HelmRelease --name=<name> --namespace=<ns> --since=30m --level=error
+kubectl describe helmrelease <name> -n <ns>
+kubectl get events -n <ns> --sort-by=.lastTimestamp | tail -40
+```
+
+If values look wrong, render locally (values.yaml differs from what's in Git):
+
+```bash
+# See what Flux will render — requires flux CLI + chart cached
+flux get helmchart -A   # find the HelmChart CR
+kubectl get helmchart <name> -n <ns> -o yaml
+```
+
+For chart version / source issues:
+
+```bash
+flux get source helm -A       # HelmRepository state
+flux get source chart -A      # Fetched chart state
+```
+
+## Decryption failures
+
+If the message mentions `sops` or `age`:
+
+```bash
+kubectl get secret -n flux-system sops-age    # must exist
+flux reconcile kustomization apps --with-source
+```
+
+If the secret exists but decryption still fails, the key doesn't match the recipient in `.sops.yaml`. Rerun `./apply-sops-age.sh` with the correct `~/homelab.agekey`. See the `managing-sops-secrets` skill for rotation.
+
+## Dependency chain recap
+
+Cluster Kustomizations (see `k3s/clusters/prod/`):
+
+```
+apps              → k3s/apps/prod              (interval 10m)
+infra-controllers → k3s/infrastructure/controllers/prod   (interval 1h, dependsOn: apps)
+infra-configs     → k3s/infrastructure/configs/prod       (interval 1h, dependsOn: infra-controllers)
+```
+
+If `apps` is red, nothing below it reconciles. Fix the top-most red Kustomization first.
+
+## Tools you can use freely
+
+Read-only kubectl is always allowed for inspection:
+
+```bash
+kubectl get kustomization,helmrelease,gitrepository,helmrepository -A
+kubectl describe <kind> <name> -n <ns>
+kubectl logs -n flux-system deploy/kustomize-controller --since=30m --tail=200
+kubectl logs -n flux-system deploy/helm-controller --since=30m --tail=200
+kubectl logs -n flux-system deploy/source-controller --since=30m --tail=200
+```
+
+`flux suspend` / `flux resume` are okay for pausing reconciliation during debugging — **always resume before ending the session.**
+
+## What NOT to do
+
+- Don't `kubectl apply -f` to fix a manifest. The cluster is reconciled from Git; your change will be overwritten within minutes, and you'll have just fixed a symptom. Commit to Git instead.
+- Don't `kubectl delete` a stuck resource without understanding why it's stuck. `prune: true` means deleting from Git deletes from cluster — if the Git source is fine, deleting the resource just makes Flux recreate it. If it's not fine, deleting masks the real bug.
+- Don't `helm upgrade` a HelmRelease manually. Flux owns that release and will revert. Fix `values:` in `helm-release.yaml`, commit.
+- Don't disable `prune: true` to "save" a resource. Remove it from Git if you want it gone; keep it in Git if you want it. No middle ground.
+
+## End with a clean handoff
+
+After debugging, leave this output in the conversation so the user has a clean record:
+
+```bash
+flux get kustomization -A
+flux get helmrelease -A
+```
+
+Both should be all `True` — if not, clearly state what's still red and why.

--- a/.claude/skills/validating-manifests/SKILL.md
+++ b/.claude/skills/validating-manifests/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: validating-manifests
+description: Run the exact local validation checks that CI runs — kustomize build on all three overlays plus the SOPS encryption check — before pushing a commit. Use before opening a PR, when the user asks to "validate", "lint", "check before pushing", "make sure CI will pass", or after any change to `k3s/` manifests or `.enc.yaml` files.
+---
+
+# Validating manifests
+
+Three CI jobs gate every PR: `Kustomize Build`, `Kubernetes Policy Check` (Datree, advisory), and `SOPS Encryption Check`. Running their logic locally before pushing saves a round-trip and catches the vast majority of problems the cluster would also fail on.
+
+## The pre-push checklist
+
+Run these from the repo root. Each line is cheap; run them all.
+
+```bash
+# 1. Kustomize overlays — these are exactly what .github/workflows/kustomize-build.yaml runs
+kustomize build k3s/apps/prod > /dev/null
+kustomize build k3s/infrastructure/controllers/prod > /dev/null
+kustomize build k3s/infrastructure/configs/prod > /dev/null
+
+# 2. SOPS encryption — mirrors .github/workflows/sops-encryption-check.yaml
+find . -name "*.enc.yaml" -not -path "./.git/*" -print0 \
+  | xargs -0 -I {} sh -c 'grep -q "^sops:" "{}" || echo "NOT encrypted: {}"'
+```
+
+Pass criteria:
+
+- The three `kustomize build` commands all exit 0 with no stderr output. Any error = CI will fail on the same overlay with the same error.
+- The `find` prints nothing. Any output = a file is unencrypted and will fail CI.
+
+## What each check catches
+
+**`kustomize build k3s/apps/prod`** — resolves every app's base + prod overlay together.
+- Missing file referenced in a `kustomization.yaml`
+- Missing app folder listed in a parent `kustomization.yaml`
+- Duplicate resource names across bases
+- Malformed YAML
+- Invalid patch targets
+
+**`kustomize build k3s/infrastructure/controllers/prod`** — every HelmRelease, HelmRepository, and operator.
+- HelmRelease referencing a HelmRepository that doesn't exist (or wrong namespace)
+- Missing `namespace.yaml` when the chart expects the namespace pre-created
+- Values file referenced via `valuesFrom` but the ConfigMap/Secret isn't in the kustomization
+
+**`kustomize build k3s/infrastructure/configs/prod`** — Traefik ingress routes, middlewares, cert-manager issuers, CNPG backup configs.
+- IngressRoute pointing at a Service that isn't in scope
+- Certificate referencing a ClusterIssuer that isn't in base
+- ScheduledBackup referencing a Cluster (CNPG) that doesn't exist
+
+**SOPS check** — any `*.enc.yaml` without the trailing `sops:` block. If you hand-edited an encrypted file or forgot to run `sops --encrypt`, this catches it before GitHub does.
+
+## What's NOT caught by local validation
+
+These pass `kustomize build` but still fail at reconcile time:
+
+- **Wrong `sourceRef.namespace` on a HelmRelease** — renders fine, fails when Flux tries to fetch the chart. Confirm by comparing to a working neighbor.
+- **Image tag doesn't exist** — `kustomize build` doesn't pull images. Renovate or a typo check will catch it; otherwise you'll see it in `kubectl describe pod` after reconcile.
+- **Datree policy violations** (missing resource limits, mutable tags, missing security context). The `kubernetes-policy-check` job is **advisory** — it won't block merge, but it will surface suggestions in CI logs. You can run it locally if you have `datree` installed; skip otherwise.
+- **SOPS decryption at runtime** — local validation only checks *that* files are encrypted, not that the cluster has the right key. See the `troubleshooting-flux` skill if Flux reports decryption failures after merge.
+
+## Running the checks as a single command
+
+```bash
+(set -e
+ for overlay in k3s/apps/prod k3s/infrastructure/controllers/prod k3s/infrastructure/configs/prod; do
+   echo "=== $overlay ==="
+   kustomize build "$overlay" > /dev/null
+ done
+ echo "=== SOPS check ==="
+ bad=$(find . -name "*.enc.yaml" -not -path "./.git/*" -print0 | xargs -0 -I {} sh -c 'grep -q "^sops:" "{}" || echo {}')
+ if [ -n "$bad" ]; then echo "NOT encrypted:"; echo "$bad"; exit 1; fi
+ echo "All checks passed."
+)
+```
+
+## When a check fails
+
+- **`accumulating resources: <path>: evalsymlink failure`** — a `kustomization.yaml` references a file or folder that doesn't exist. Fix the path.
+- **`no matches for Id <kind>` (on CRDs)** — often fine locally if the CRD isn't installed. CI uses the same `kustomize build` without cluster access, so this usually still works. If it breaks CI, you likely need `spec.install.crds: Create` on a HelmRelease, or a CRD manifest in base.
+- **`duplicate resource <name>`** — two bases define the same resource. Either remove one or rename it.
+- **`NOT encrypted: <path>`** — run `sops --encrypt --in-place <path>` or `sops edit <path>` and save.
+
+## One more thing before pushing
+
+Scan the diff for anything that *looks* like a secret but isn't in a `.enc.yaml`:
+
+```bash
+git diff --cached | grep -iE '(password|token|secret|api[_-]?key|bearer|authorization).*[:=]' || true
+```
+
+False positives are common (env var names, labels), but a real leak surfaces here. If there's a genuine secret value, move it into a `.k8s.enc.yaml` and encrypt before committing — see the `managing-sops-secrets` skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+Instructions for Claude agents working in this repository. Read this once per session.
+
+## Quick context
+
+This is Paul's personal homelab — a K3s HA cluster on Proxmox VMs, managed GitOps-style with FluxCD. The repo is the **single source of truth**: Flux reconciles cluster state from `main`. No manual `kubectl apply`, no out-of-band changes, no secrets in plaintext. See [README.md](README.md) for the full architecture rationale.
+
+The repo is public on purpose: it's portfolio / proof-of-work. Treat changes like you would a real production environment — small, reviewable, reversible.
+
+## Repository layout
+
+```
+ansible/        Cluster bootstrap + node config (K3s, HAProxy, Keepalived, NFS, GPU)
+terraform/      Proxmox VM provisioning
+k3s/
+├── apps/
+│   ├── base/           Reusable manifests (deployment, service, namespace) per app
+│   └── prod/           Prod overlay (ConfigMaps, PVCs, encrypted secrets)
+├── infrastructure/
+│   ├── controllers/
+│   │   ├── base/       HelmReleases + HelmRepositories (cert-manager, loki, …)
+│   │   └── prod/       Prod-specific overrides
+│   └── configs/
+│       ├── base/       Shared configs (ClusterIssuers, Cloudflare tokens)
+│       └── prod/       Prod ingress, Traefik routes, CNPG backup config
+└── clusters/prod/      Flux entry points: flux-system/, apps.yaml, infrastructure.yaml
+.github/workflows/      CI: kustomize-build, kubernetes-policy-check (Datree), sops-encryption-check
+.sops.yaml              SOPS creation rules (age recipient)
+renovate.json           Dependency grouping + automerge policy
+apply-sops-age.sh       Uploads age key to cluster as flux-system/sops-age secret
+.envrc                  direnv: SOPS_AGE_KEY_FILE, KUBECONFIG, ANSIBLE_INVENTORY
+```
+
+Flux reconciliation DAG: `apps` (10m) → `infra-controllers` (1h) → `infra-configs` (1h). Everything under `k3s/clusters/prod/` is the Flux entrypoint — don't rename without updating `gotk-sync.yaml`.
+
+## Non-negotiable rules
+
+1. **No `kubectl apply`, `helm install`, or `helm upgrade` against the cluster.** The cluster is a reflection of `main`. If you want a change, it goes through Git. `kubectl get/describe/logs` for *inspection* is fine.
+2. **Secrets are always encrypted before commit.** Files matching `*.enc.yaml` must contain a `sops:` block. The `sops-encryption-check` CI job blocks merges otherwise. Never commit a decrypted `.enc.yaml` even temporarily — use `sops edit` or encrypt-in-place.
+3. **Don't bump versions by hand.** Renovate owns image tags, Helm chart versions, and Terraform providers. If you see an outdated version, check if a Renovate PR is open before touching it.
+4. **No new top-level directories without reason.** Apps go under `k3s/apps/`; cluster services under `k3s/infrastructure/controllers/` or `/configs/`.
+5. **Match existing patterns.** Look at a neighbor (jellyfin for apps, loki for HelmReleases) before inventing a new shape.
+
+## Secrets & SOPS
+
+- Age recipient: `age1ys5az3gtql0nut2ldf88waz3jkmwzuvfl7gcrn9sja2luvnaud2s6u3834` (pinned in `.sops.yaml`).
+- Private key lives at `~/homelab.agekey` on Paul's machine; exported via `.envrc` as `SOPS_AGE_KEY_FILE`.
+- Two file-naming conventions, chosen by `.sops.yaml` regex:
+  - `*.k8s.enc.yaml` — Kubernetes Secrets; only `data` / `stringData` fields are encrypted (metadata stays readable for Kustomize).
+  - `*.enc.yaml` — Terraform/Ansible variable files; entire file encrypted.
+- Flux decrypts in-cluster using the `sops-age` Secret in `flux-system`. If a fresh cluster can't decrypt, re-run `./apply-sops-age.sh`.
+
+See the `managing-sops-secrets` skill for the encrypt/edit/rotate workflow.
+
+## Adding or changing manifests
+
+- **New app:** follow `k3s/apps/base/jellyfin/` + `k3s/apps/prod/jellyfin/`. Append to `k3s/apps/base/kustomization.yaml` AND `k3s/apps/prod/kustomization.yaml`. The `adding-flux-app` skill has the exact template.
+- **New cluster service (Helm chart):** follow `k3s/infrastructure/controllers/base/loki/`. See `adding-helmrelease`.
+- **New ingress route or middleware:** `k3s/infrastructure/configs/prod/traefik/`.
+- **Every new directory needs a `kustomization.yaml`** listing its resources, and its parent's `kustomization.yaml` needs to reference it. The `kustomize-build` CI job will fail otherwise.
+
+## Validate before pushing
+
+Run locally before opening a PR:
+
+```bash
+kustomize build k3s/apps/prod > /dev/null
+kustomize build k3s/infrastructure/controllers/prod > /dev/null
+kustomize build k3s/infrastructure/configs/prod > /dev/null
+find . -name "*.enc.yaml" -not -path "./.git/*" -exec grep -L "^sops:" {} +
+```
+
+The three `kustomize build` calls are exactly what `kustomize-build.yaml` runs in CI. The `find` replicates the SOPS check. See the `validating-manifests` skill.
+
+## Working with Flux (inspection only)
+
+```bash
+flux get kustomization -A           # Reconciliation status
+flux get helmrelease -A
+flux logs --all-namespaces --level=error --since=30m
+flux reconcile source git flux-system   # Force pull of latest main
+flux reconcile kustomization apps --with-source
+```
+
+`flux suspend` / `flux resume` are allowed for temporary pauses, but always resume before ending a session. See `troubleshooting-flux` for a triage flow.
+
+## Git & PR conventions
+
+- Branch off `main`. Conventional commits (`feat:`, `fix:`, `chore(deps):`, …) — see recent `git log`.
+- PRs are the unit of change. Renovate PRs automerge on green CI for non-major updates.
+- CI must be green before merge: `Kustomize Build`, `Kubernetes Policy Check` (Datree, advisory), `SOPS Encryption Check`.
+- After merge, Flux reconciles within 10 minutes for apps, 1 hour for infra. Use `flux reconcile` to speed up a specific change if needed.
+
+## Common gotchas
+
+- **Kustomize silently skips files not listed in `kustomization.yaml`.** A new `*.yaml` that isn't referenced will never reach the cluster — and CI won't flag it. Always update the parent `kustomization.yaml`.
+- **HelmRelease `chart.spec.sourceRef.namespace` matters.** The `HelmRepository` is usually in `monitoring` or `flux-system`; copy from an existing release.
+- **Flux won't re-apply an identical manifest.** If something looks stuck, check `flux get kustomization` for error status before assuming it's a timing issue.
+- **SOPS metadata is encrypted too.** Never edit `.enc.yaml` files by hand — use `sops edit`. A hand-edited file won't decrypt.
+- **`prune: true` is set on all Kustomizations.** Removing a resource from Git deletes it from the cluster. Double-check before deleting manifests for stateful workloads (PVCs, CNPG Clusters).
+- **Renovate groups exist for a reason** (`jellyfin-stack`, `arr-stack`, `loki-promtail`). Don't split these updates manually — they're coupled by API compatibility.
+
+## Tone
+
+Paul knows his stack. Explain the *why* only when it's non-obvious or when you're suggesting something unusual. Match the terseness of existing manifests and commit messages. When in doubt, read a neighbor and do the same thing.


### PR DESCRIPTION
## Summary

Introduces a `.claude/` configuration layer so current and future Claude agents can work effectively in this repo without re-deriving conventions each session. No runtime or cluster impact — this is documentation-only.

## What's in the PR

- **`CLAUDE.md`** at the repo root — quick onboarding: architecture, repo layout, non-negotiable rules (no `kubectl apply`, SOPS-before-commit, Renovate owns versions), the Flux reconciliation DAG, validation steps, and common gotchas.
- **Six skills** under `.claude/skills/`, each a self-contained workflow:
  - `conventional-git` — branch + commit conventions for this repo (no ticket prefix, no `release/` branches, homelab-tuned scopes).
  - `managing-sops-secrets` — the `*.k8s.enc.yaml` vs `*.enc.yaml` split, encrypt/edit/rotate workflow, and the `apply-sops-age.sh` recovery path.
  - `validating-manifests` — the exact `kustomize build` + SOPS-encryption commands CI runs, so they can be mirrored locally before pushing.
  - `adding-flux-app` — base + prod overlay scaffolding for raw-manifest apps, cloned from the jellyfin/sonarr pattern.
  - `adding-helmrelease` — HelmRelease/HelmRepository pair under `infrastructure/controllers/`, including the `sourceRef.namespace` trap.
  - `troubleshooting-flux` — top-down triage for failing Kustomizations / HelmRelease / decryption errors.

## Design notes

- Skill descriptions are gerund-named, third-person, and front-load trigger phrases — per Anthropic's skill-discovery guidance.
- Each skill body stays under ~200 lines and cross-references siblings rather than duplicating (progressive disclosure).
- The existing worktree-local `.claude/settings.local.json` was left untouched.

## Reviewer checklist

- [ ] `CLAUDE.md` reflects how you actually want agents to operate.
- [ ] Skill conventions (scopes, branch prefixes, validation commands) match your mental model.
- [ ] No unencrypted secrets or runtime manifests touched (there aren't any — documentation-only PR).