### PR TITLE
feat(goldilocks): add VPA-backed resource recommendation dashboard

### DIFF
--- a/k3s/infrastructure/configs/prod/traefik/ingress-routes.yaml
+++ b/k3s/infrastructure/configs/prod/traefik/ingress-routes.yaml
@@ -328,3 +328,18 @@ spec:
       services:
         - name: lazylibrarian
           port: http
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: goldilocks
+  namespace: goldilocks
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`goldilocks-prod.maurovi.ch`)
+      services:
+        - name: goldilocks-dashboard
+          port: http

--- a/k3s/infrastructure/controllers/base/goldilocks/helm-release.yaml
+++ b/k3s/infrastructure/controllers/base/goldilocks/helm-release.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: goldilocks
+  namespace: goldilocks
+spec:
+  interval: 10m
+  timeout: 5m
+  chart:
+    spec:
+      chart: goldilocks
+      version: 10.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: fairwinds-stable
+        namespace: goldilocks
+  # https://github.com/FairwindsOps/charts/blob/master/stable/goldilocks/values.yaml
+  values:
+    # Goldilocks depends on VPA recommender; install it as a sub-chart
+    # rather than managing a separate release.
+    vpa:
+      enabled: true
+      updater:
+        enabled: false
+
+    controller:
+      # Create VPAs for every namespace by default. Opt-out per namespace
+      # with the label goldilocks.fairwinds.com/enabled=false.
+      flags:
+        on-by-default: "true"
+
+    dashboard:
+      replicaCount: 1

--- a/k3s/infrastructure/controllers/base/goldilocks/helm-repository.yaml
+++ b/k3s/infrastructure/controllers/base/goldilocks/helm-repository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: fairwinds-stable
+  namespace: goldilocks
+spec:
+  interval: 1h
+  url: https://charts.fairwinds.com/stable

--- a/k3s/infrastructure/controllers/base/goldilocks/kustomization.yaml
+++ b/k3s/infrastructure/controllers/base/goldilocks/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ./namespace.yaml
+  - ./helm-repository.yaml
+  - ./helm-release.yaml

--- a/k3s/infrastructure/controllers/base/goldilocks/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/goldilocks/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: goldilocks

--- a/k3s/infrastructure/controllers/base/kustomization.yaml
+++ b/k3s/infrastructure/controllers/base/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - ./tailscale
   - ./traefik
   - ./pihole-nebula-sync
+  - ./goldilocks


### PR DESCRIPTION
## Summary

- Deploy [Goldilocks](https://github.com/FairwindsOps/goldilocks) (Fairwinds chart `10.3.0`) as a new infrastructure controller, with VPA recommender bundled as a sub-chart (`vpa.enabled: true`, updater disabled).
- Configure the controller with `--on-by-default=true` so a VPA is created for every workload in every namespace; any namespace can opt-out via the `goldilocks.fairwinds.com/enabled=false` label.
- Expose the dashboard at `https://goldilocks-prod.maurovi.ch` via a Traefik `IngressRoute` targeting `goldilocks-dashboard:http`.

## Why

Several workloads (lazylibrarian, audiobookshelf, …) run without resource requests/limits. Goldilocks turns that guesswork into data — observe real usage via VPA recommendations before sizing new deployments.

## Notes for reviewers

- No secrets or ConfigMaps: Goldilocks reads in-cluster VPA objects and exposes a read-only dashboard — no auth, no env config.
- The dashboard has no built-in authentication; access control relies on the existing Cloudflare tunnel + DNS scoping pattern used for other `*-prod.maurovi.ch` services.
- New `HelmRepository` `fairwinds-stable` in the `goldilocks` namespace — no prior Fairwinds chart source in the repo.
- Chart version pinned to `10.3.0`; Renovate will track upgrades.

## Test plan

- [ ] `kustomize build k3s/apps/prod`, `…/controllers/prod`, `…/configs/prod` all succeed locally (confirmed).
- [ ] CI green: `Kustomize Build`, `Kubernetes Policy Check`, `SOPS Encryption Check`.
- [ ] After merge + Flux reconcile: `flux get helmrelease -n goldilocks goldilocks` shows `Ready=True`.
- [ ] `kubectl get vpa -A` shows VPAs populated across namespaces.
- [ ] `https://goldilocks-prod.maurovi.ch` loads the dashboard.