### PR TITLE
chore(goldilocks): label all namespaces to get monitored

### DIFF
--- a/k3s/apps/base/apprise/namespace.yaml
+++ b/k3s/apps/base/apprise/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: apprise
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/audiobookshelf/namespace.yaml
+++ b/k3s/apps/base/audiobookshelf/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: audiobookshelf
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/beszel/hub/namespace.yaml
+++ b/k3s/apps/base/beszel/hub/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: beszel
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/gatus/namespace.yaml
+++ b/k3s/apps/base/gatus/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gatus
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/gotify/namespace.yaml
+++ b/k3s/apps/base/gotify/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gotify
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/it-tools/namespace.yaml
+++ b/k3s/apps/base/it-tools/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: it-tools
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/jellyfin/namespace.yaml
+++ b/k3s/apps/base/jellyfin/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: jellyfin
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/jellyseerr/namespace.yaml
+++ b/k3s/apps/base/jellyseerr/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: jellyseerr
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/lazylibrarian/namespace.yaml
+++ b/k3s/apps/base/lazylibrarian/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: lazylibrarian
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/miniflux/miniflux.yaml
+++ b/k3s/apps/base/miniflux/miniflux.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: miniflux
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k3s/apps/base/openspeedtest/namespace.yaml
+++ b/k3s/apps/base/openspeedtest/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openspeedtest
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/paperless-ngx/namespace.yaml
+++ b/k3s/apps/base/paperless-ngx/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: paperless-ngx
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/prowlarr/namespace.yaml
+++ b/k3s/apps/base/prowlarr/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: prowlarr
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/radarr/namespace.yaml
+++ b/k3s/apps/base/radarr/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: radarr
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/recipes/namespace.yaml
+++ b/k3s/apps/base/recipes/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: recipes
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/renovate/namespace.yaml
+++ b/k3s/apps/base/renovate/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: renovate
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/sabnzbd/namespace.yaml
+++ b/k3s/apps/base/sabnzbd/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: sabnzbd
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/sonarr/namespace.yaml
+++ b/k3s/apps/base/sonarr/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: sonarr
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/apps/base/vaultwarden/namespace.yaml
+++ b/k3s/apps/base/vaultwarden/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: vaultwarden
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/configs/prod/traefik/external-services/namespace.yaml
+++ b/k3s/infrastructure/configs/prod/traefik/external-services/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: external-routes
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/cert-manager/cert-manager.yaml
+++ b/k3s/infrastructure/controllers/base/cert-manager/cert-manager.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/k3s/infrastructure/controllers/base/cloudflared/cloudflared-namespace.yaml
+++ b/k3s/infrastructure/controllers/base/cloudflared/cloudflared-namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cloudflared
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/cloudnativepg/cloudnative-pg.yaml
+++ b/k3s/infrastructure/controllers/base/cloudnativepg/cloudnative-pg.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cnpg-system
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/k3s/infrastructure/controllers/base/goldilocks/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/goldilocks/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: goldilocks
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/grafana/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/grafana/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: grafana
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/homarr/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/homarr/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: homarr
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/intel-device-plugin-operator/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/intel-device-plugin-operator/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: intel-devices
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/loki/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/loki/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: loki
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/monitoring/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/monitoring/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/nfs-subdir-external-provisioner/nfs-subdir-external-provisioner.yaml
+++ b/k3s/infrastructure/controllers/base/nfs-subdir-external-provisioner/nfs-subdir-external-provisioner.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: nfs-provisioner
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/k3s/infrastructure/controllers/base/node-feature-discovery/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/node-feature-discovery/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: node-feature-discovery
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/pgadmin/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/pgadmin/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: pgadmin
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/pihole-nebula-sync/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/pihole-nebula-sync/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: pihole-nebula-sync
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/portainer/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/portainer/namespace.yaml
@@ -4,4 +4,5 @@ kind: Namespace
 metadata:
   name: portainer
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     pod-security.kubernetes.io/enforce: privileged

--- a/k3s/infrastructure/controllers/base/promtail/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/promtail/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: promtail
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/k3s/infrastructure/controllers/base/redis/redis.yaml
+++ b/k3s/infrastructure/controllers/base/redis/redis.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redis
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/k3s/infrastructure/controllers/base/tailscale/namespace.yaml
+++ b/k3s/infrastructure/controllers/base/tailscale/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tailscale
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
Goldilocks only scans namespaces carrying
goldilocks.fairwinds.com/enabled=true; without it the dashboard is empty.